### PR TITLE
fix: terminate `autoload` option processing

### DIFF
--- a/functions/@zpm-add-autoload
+++ b/functions/@zpm-add-autoload
@@ -2,5 +2,5 @@
 
 for autoload_file in $(echo $1|tr ':' '\n'); do
   _ZPM_autoload+=("${autoload_file}")
-  autoload -Uz "${autoload_file}"
+  autoload -Uz -- "${autoload_file}"
 done

--- a/functions/@zpm-background-initialization
+++ b/functions/@zpm-background-initialization
@@ -7,7 +7,7 @@ compinit -i -d "${_ZPM_COMPDUMP}"
 local _ZPM_TMP="$(mktemp)"
 local _ZPM_TMP_ASYNC="$(mktemp)"
 
-echo "autoload -Uz $_ZPM_autoload" >> "$_ZPM_TMP"
+echo "autoload -Uz -- $_ZPM_autoload" >> "$_ZPM_TMP"
 echo 'zsh_loaded_plugins=('$_ZPM_plugins_no_source')' >> "$_ZPM_TMP"
 echo >> "$_ZPM_TMP"
 


### PR DESCRIPTION
A function name beginning with `+` (i.e. `+zlug-write-script-header`) would cause `zpm` initialization to fail:

```sh
...
zpm:init:autoload Autoload :+zlug-write-script-header:@zlug-from-deferred-source
@zpm-add-autoload:autoload:5: bad option: +l
...
```