### PR TITLE
feat: add support for calling plugin functions from command tags

### DIFF
--- a/bin/_ZPM-plugin-helper
+++ b/bin/_ZPM-plugin-helper
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
-fpath+=("${_ZPM_DIR}/functions")
+fpath+=("${_ZPM_DIR}/functions" "${_ZPM_CACHE_DIR}/functions")
 
 if [[ "$CLICOLOR" != "0" ]]; then
   typeset -gA c=(
@@ -27,6 +27,9 @@ autoload -Uz                    \
   @zpm-get-plugin-path          \
   @zpm-get-plugin-type          \
   @zpm-log
+
+(( $#_ZPM_autoload )) && \
+  autoload -Uz -- ${(z)_ZPM_autoload}
 
 local Plugin_name=$(@zpm-get-plugin-name "$2")
 

--- a/functions/@zpm-launch-plugin-helper
+++ b/functions/@zpm-launch-plugin-helper
@@ -1,0 +1,24 @@
+#!/usr/bin/env zsh
+
+local Command="$1"
+
+local Format
+local Launcher
+local Item
+
+if is-callable "rush"; then
+  Format='%s\n'
+  Launcher="rush"
+  Item='"{}"'
+else
+  Format='%s\0'
+  Launcher="xargs -0 -P32 -n1 -I{}"
+  Item='{}'
+fi
+
+shift
+
+printf $Format "$@" | \
+  _ZPM_CACHE_DIR="$_ZPM_CACHE_DIR" \
+  _ZPM_autoload="$_ZPM_autoload" \
+  ${(z)Launcher} "${_ZPM_DIR}/bin/_ZPM-plugin-helper" $Command $Item

--- a/functions/@zpm-load-plugins
+++ b/functions/@zpm-load-plugins
@@ -25,8 +25,7 @@ for plugin in $@; do
 done
 
 if [[ -n "$Plugins_Install[@]" ]]; then;
-  printf '%s\0' "${Plugins_Install[@]}" | \
-    xargs -0 -P16 -n1 -I{} "${_ZPM_DIR}/bin/_ZPM-plugin-helper" install '{}'
+  @zpm-launch-plugin-helper install "${Plugins_Install[@]}"
 fi
 
 for plugin_name in $Plugins_Load_Order; do

--- a/functions/@zpm-upgrade
+++ b/functions/@zpm-upgrade
@@ -11,10 +11,6 @@ for plugin (${_Plugins_Upgrade}); do
   _Plugins_Upgrade_full+=($_ZPM_plugins_full[$plugin])
 done
 
-if (( $+commands[rush] )); then
-  printf '%s\n' "${_Plugins_Upgrade_full[@]}" | _ZPM_DIR="$_ZPM_DIR" rush "${_ZPM_DIR}/bin/_ZPM-plugin-helper" upgrade '"{}"'
-else
-  printf '%s\0' "${_Plugins_Upgrade_full[@]}" | _ZPM_DIR="$_ZPM_DIR" xargs -0 -P32 -n1 -I{} "${_ZPM_DIR}/bin/_ZPM-plugin-helper" upgrade '{}'
-fi
+@zpm-launch-plugin-helper upgrade "${_Plugins_Upgrade_full[@]}"
 
 @zpm-clean

--- a/lib/init.zsh
+++ b/lib/init.zsh
@@ -29,6 +29,7 @@ autoload -Uz \
   @zpm-get-plugin-path \
   @zpm-get-plugin-type \
   @zpm-initialize-plugin \
+  @zpm-launch-plugin-helper \
   @zpm-load-plugins \
   @zpm-log \
   @zpm-no-source \


### PR DESCRIPTION
This PR adds support for calling functions defined by loaded plugins when evaluating the command tags `gen-completion`, `gen-plugin`, and `hook`. Calling a command installed by a plugin is already supported via the `PATH` export in `zpm.zsh`. The builtin plugin `@zpm` is not supported in the context of evaluating command tags. The shell that is running `ZPM-plugin-helper` does not support modifying the ZPM plugin environment.

I refactored the code used to launch the `upgrade` and `install` tasks through `ZPM-plugin-helper` into a new function called `@zpm-launch-plugin-helper`. The function will use `rush` if callable. This also extends `@zpm-load-plugins` to use `rush` when available.
