### PR TITLE
feat: update support for Oh My Zsh plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Zpm is a plugin manager for ZSH who combines the imperative and declarative appr
 * Dependencies between packages
 * Many hooks
 * Function autoloading
-* ZPM plugins are compatible with [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
+* ZPM plugins are compatible with [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)
 * ZPM runs on Linux, Android, FreeBSD and macOS
 * Extensible
 

--- a/bin/_ZPM-plugin-helper
+++ b/bin/_ZPM-plugin-helper
@@ -61,10 +61,12 @@ if [[ "$1" == "upgrade" ]]; then
 else
   local Plugin_git_url=$(@zpm-get-plugin-git-url "$Plugin_name" "$Plugin_type")
   if [[ "$Plugin_type" == "omz" ]]; then
-    if [[ ! -e "${Plugin_git_url}" ]]; then
+    if [[ ! -e "${Plugin_git_root_path}" ]]; then
       git clone --recursive "${Plugin_git_url}" --depth 1 --single-branch "${Plugin_git_root_path}" </dev/null >/dev/null 2>/dev/null
     fi
-    ln -s "${HOME}/.oh-my-zsh/plugins/${Plugin_basename}" "$Plugin_path" 2>/dev/null
+    if [[ "$Plugin_path" != "$Plugin_git_root_path" ]]; then
+      ln -s "${Plugin_git_root_path}/plugins/${Plugin_basename}" "$Plugin_path" 2>/dev/null
+    fi
     true
   elif [[ "$Plugin_type" == "empty" ]]; then
     mkdir -p "${Plugin_path}"

--- a/functions/@zpm-get-plugin-git-root-path
+++ b/functions/@zpm-get-plugin-git-root-path
@@ -4,7 +4,7 @@ local Plugin_path="$1"
 local Plugin_type="$2"
 
 if [[ "$Plugin_type" == "omz" ]]; then
-  echo "${HOME}/.oh-my-zsh"
+  echo "${ZSH:-${HOME}/.oh-my-zsh}"
   return 0
 fi
 

--- a/functions/@zpm-get-plugin-git-url
+++ b/functions/@zpm-get-plugin-git-url
@@ -9,4 +9,6 @@ elif [[ "$Plugin_type" == "gitlab" ]]; then
   echo "https://gitlab.com/${Plugin_name}"
 elif [[ "$Plugin_type" == "bitbucket" ]]; then
   echo "https://bitbucket.com/${Plugin_name}"
+elif [[ "$Plugin_type" == "omz" ]]; then
+  echo "https://github.com/ohmyzsh/ohmyzsh"
 fi

--- a/functions/@zpm-get-plugin-link
+++ b/functions/@zpm-get-plugin-link
@@ -24,6 +24,6 @@ if [[ "$plugin_type" == 'zpm' ]]; then
 fi
 
 if [[ "$plugin_type" == 'omz' ]]; then
-  echo "https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/${plugin_name#*/}"
+  echo "https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/${plugin_name#*/}"
   return 0
 fi


### PR DESCRIPTION
This PR adds slightly better support for [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh) (OMZ):

- Fix detection of the Oh My Zsh installation directory. This fixes OMZ plugins where OMZ was not already downloaded to `~/.oh-my-zsh`.
- Add support for the OMZ GitHub URL.
- Allow `ZSH` to override the default OMZ path of `~/.oh-my-zsh`. Technically this is a breaking change, but OMZ plugin support was not working without OMZ already installed at ~/.oh-my-zsh so the feature wasn't completely available.
- Update OMZ links to point to the correct GitHub repo.

OMZ can now be installed anywhere, including as a `zpm` plugin with the following:

```zsh
# If do source `oh-my-zsh.sh`, you may want to set the following so that OMZ uses the same file as `zpm`:
ZSH_COMPDUMP="${_ZPM_CACHE_DIR}/zcompdump"

zpm load ohmyzsh/ohmyzsh,source:oh-my-zsh.sh # ZSH set by source to the plugin directory

# - or -

ohmyzsh/ohmyzsh,gen-plugin:'<<<"export ZSH=${(q)Plugin_path}"' # Direct export without souring all of OMZ
```

Note that if you manage OMZ as a `zpm` plugin, it must be loaded in a separate  `zpm load` command _before_ loading other OMZ plugins (e.g. `@omz/git`) to avoid a race condition during parallel loading of `zpm` plugins.

I have another feature in progress which provides a special package named `@omz` that will install to `${_ZPM_PLUGIN_DIR}/@omz` and source `oh-my-zsh.sh` by default, but I have to figure out a clean way to do dependency "injection", so that if you do `zpm load @omz @omz/git` then it will work even with the plugins loaded in parallel. I'm currently detecting whether `@omz` is in `_ZPM_loaded_plugins`, and if so, setting `ZSH` to that plugin path so that even if a dependent plugin is loaded first, it will checkout into the correct `ZSH` path. If there's a better way of doing that, let me know.
