### PR TITLE
readme: add workaround instructions for powerlevel10k

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,10 +452,29 @@ BITBUCKET_MIRROR="Some url"
 
 ## Troubleshooting
 
-If you have problems with `zpm` try:
+### Powerlevel10k
+
+Powerlevel10k loads extra modules in its installation directory, which it [automatically detects by taking the file containing its init code, making it absolute, and taking its directory](https://github.com/romkatv/powerlevel10k/blob/0cc19ac2ede35fd8accff590fa71df580dc7e109/powerlevel10k.zsh-theme#L20). However, as zpm combines plugins into one fast-loading cache file, this automatic detection would break.
+
+As a workaround, you have to explicitly tell Powerlevel10k where it is installed. This needs to be done before the cache file is loaded, which means before zpm itself is loaded, like this:
 
 ```sh
-rm -rf "${TMPDIR:-/tmp}/zsh-${UID:-user}"
+# Adjust the path accordingly if your zpm is not installed at `~/.zpm` or you're
+# using a powerlevel10k fork
+export POWERLEVEL9K_INSTALLATION_DIR=~/.zpm/plugins/romkatv---powerlevel10k
+source ~/.zpm/zpm.zsh
+
+# ...
+
+zpm load romkatv/powerlevel10k
+```
+
+### Update to latest zpm
+
+If you have problems with `zpm` try updating:
+
+```sh
+rm -rf "${TMPDIR:-/tmp}/zsh-${UID:-user}" # clear the cache
 cd ~/.zpm
 git pull
 ```


### PR DESCRIPTION
This is probably enough to address #48?

## The problem

Powerlevel10k uses [this line](https://github.com/romkatv/powerlevel10k/blob/0cc19ac2ede35fd8accff590fa71df580dc7e109/powerlevel10k.zsh-theme#L20) to determine its install directory:

```zsh
(( $+__p9k_root_dir )) || typeset -gr __p9k_root_dir=${POWERLEVEL9K_INSTALLATION_DIR:-${${(%):-%x}:A:h}}
```

<details>
<summary>Explaining <code class="notranslate">${POWERLEVEL9K_INSTALLATION_DIR:-${${(%):-%x}:A:h}}</code></summary>
<ul dir="auto">
<li>This is setting up <code class="notranslate">__p9k_root_dir</code></li>
<li>The default value is <code class="notranslate">$POWERLEVEL9K_INSTALLATION_DIR</code></li>
<li>If that's not set, it sets it to <code class="notranslate">${${(%):-%x}:A:h}}</code>, which is:
<ul dir="auto">
<li>The executing script's path (<code class="notranslate">${(%):-%x}</code>; the parameter expansion flag <code class="notranslate">(%)</code> enables the "%x" syntax; <code class="notranslate">%x</code> means the executing script's path)</li>
<li>Converted into an absolute path (the <code class="notranslate">:A</code> expansion modifier)</li>
<li>Then with the last pathname component removed (the <code class="notranslate">:h</code> expansion modifier)</li>
<li>This comes out to <code class="notranslate">/tmp/zsh-1000/</code> in the cache file, causing the error in <span class="reference"><svg class="octicon octicon-issue-opened open mr-1" title="Open" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path></svg><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1167280973" data-permission-text="Title is private" data-url="https://github.com/zpm-zsh/zpm/issues/48" data-hovercard-type="issue" data-hovercard-url="/zpm-zsh/zpm/issues/48/hovercard" href="https://github.com/zpm-zsh/zpm/issues/48">(anon):source:27: no such file or directory: /tmp/zsh-1000/internal/p10k.zsh<span class="issue-shorthand">&nbsp;#48</span></a></span></li>
</ul>
</li>
</ul>
</details>

TL;DR: Powerlevel10k assumes its init script is its own file in its installation directory; this assumption is broken by zpm's caching mechanism.

## The workaround

This PR documents a workaround for this situation in README. An explanation of the situation is provided as well.

```sh
export POWERLEVEL9K_INSTALLATION_DIR=~/.zpm/plugins/romkatv---powerlevel10k
source ~/.zpm/zpm.zsh
# ...
zpm load romkatv/powerlevel10k
```