### PR TITLE
Add -fSL flag to let curl follow redirections

### DIFF
--- a/bin/@zpm-plugin-helper
+++ b/bin/@zpm-plugin-helper
@@ -101,7 +101,7 @@ if [[ "$Plugin_origin_type" == 'git' ]]; then
   _msg $?
 elif [[ "$Plugin_origin_type" == 'remote' ]]; then
   mkdir -p "${Plugin_destination_path:h}"
-  curl --silent "${Plugin_origin}" --output "${Plugin_destination_path}" 2>/dev/null
+  curl -fSL --silent "${Plugin_origin}" --output "${Plugin_destination_path}" 2>/dev/null
   _msg $?
 elif [[ "$Plugin_origin_type" == 'dir-link' ]]; then
   if [[ "$Command" == 'install' ]]; then


### PR DESCRIPTION
Without -L flag curl doesn't follow the redirection. I think there's no reason to omit this.

-fS helps to understand what's happening when curl fails. Having these flags it would be much more useful.

I filed #63 for this issue.