### PR TITLE
Optimize zpm logging

### DIFF
--- a/functions/@zpm-log
+++ b/functions/@zpm-log
@@ -1,17 +1,18 @@
 #!/usr/bin/env zsh
 
-if [[ -n "$DEBUG" &&  "${1}:" == "${DEBUG}:"*  ]]; then
-  local num=0
-  local i=0
-
-  while [[ $i -lt $(( ${#1} + 1 )) ]]; do
-    num=$(( $num + $(LC_CTYPE=C printf '%d' "'${1[$i]})") ))
-    i=$(( $i + 1))
-  done
-
-  color=$(( $num % 6 + 1 ))
-
-  echo -n "[1;3${color}m$1 [0m"
+# Print debug messages when DEBUG is set and the message prefix matches DEBUG.
+# The prefix is shown in a deterministic colour based on its characters.
+if [[ -n "$DEBUG" && "${1}:" == "${DEBUG}:"* ]]; then
+  local prefix="$1"
   shift
-  echo "$@"
+
+  local num=0
+  local i=1
+  while (( i <= ${#prefix} )); do
+    num=$(( num + $(LC_CTYPE=C printf '%d' "'${prefix[i]}'") ))
+    (( i++ ))
+  done
+  local color=$(( num % 6 + 1 ))
+
+  print -P "%F{${color}}${prefix}%f $*"
 fi


### PR DESCRIPTION
## Summary
- improve `@zpm-log` by giving it deterministic coloured output

## Testing
- `make test` *(fails: zsh: can't open input file: tests/base.test.zsh)*
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_684161e4c608832a90cad805cff163cf