### PR TITLE
[ZSH_TMP_DIR] /tmp -> XDG_STATE_HOME

### DIFF
--- a/zpm.zsh
+++ b/zpm.zsh
@@ -14,7 +14,7 @@ export PMSPEC="0fbs"
 0="${${(M)0:#/*}:-$PWD/$0}"
 export _ZPM_DIR="${0:h}"
 
-export ZSH_TMP_DIR="${ZSH_TMP_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/zsh}"
+export ZSH_TMP_DIR="${ZSH_TMP_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/zpm}"
 _ZPM_CACHE="${ZSH_TMP_DIR}/zpm-cache.zsh"
 _ZPM_CACHE_ASYNC="${ZSH_TMP_DIR}/zpm-cache-async.zsh"
 

--- a/zpm.zsh
+++ b/zpm.zsh
@@ -14,7 +14,7 @@ export PMSPEC="0fbs"
 0="${${(M)0:#/*}:-$PWD/$0}"
 export _ZPM_DIR="${0:h}"
 
-export ZSH_TMP_DIR="${ZSH_TMP_DIR:-${TMPDIR:-/tmp}/zsh-${UID:-user}}"
+export ZSH_TMP_DIR="${ZSH_TMP_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/zsh}"
 _ZPM_CACHE="${ZSH_TMP_DIR}/zpm-cache.zsh"
 _ZPM_CACHE_ASYNC="${ZSH_TMP_DIR}/zpm-cache-async.zsh"
 


### PR DESCRIPTION
Storing stuff needed for the shell to work under `${TMPDIR:-/tmp}` is an unexpected place to cache executable code, insecure on multiuser systems, and destroyed on reboot on some systems and rarely on others.

This PR addresses this by following the [XDG spec](https://specifications.freedesktop.org/basedir-spec/latest/) for per-use data storage.